### PR TITLE
fix: do not append zero samples to the end for the resampler

### DIFF
--- a/chromaprint/Cargo.toml
+++ b/chromaprint/Cargo.toml
@@ -12,4 +12,4 @@ exclude = ["data/**"]
 
 [dependencies]
 rustfft = "6.2.0"
-rubato = "0.15.0"
+rubato = "0.16.0"


### PR DESCRIPTION
also port two related tests from the reference implementation and leave them ignored for now as there are some inconsistencies due to different resampling method - they should not matter that much during fingerprint matching