### PR TITLE
fix(compare): fallback to "channel_layout" if "channels: None"

### DIFF
--- a/compare/src/main.rs
+++ b/compare/src/main.rs
@@ -55,6 +55,8 @@ fn calc_fingerprint(path: impl AsRef<Path>, config: &Configuration) -> anyhow::R
     let channels = track
         .codec_params
         .channels
+        // for some codecs symphonia has "channels: None", but has a channel layout, which can be converted into channels
+        .or_else(|| track.codec_params.channel_layout.map(|v| v.into_channels()))
         .context("missing audio channels")?
         .count() as u32;
     printer

--- a/fpcalc/src/main.rs
+++ b/fpcalc/src/main.rs
@@ -200,6 +200,8 @@ impl AudioReader {
         let channel_count = track
             .codec_params
             .channels
+            // for some codecs symphonia has "channels: None", but has a channel layout, which can be converted into channels
+            .or_else(|| track.codec_params.channel_layout.map(|v| v.into_channels()))
             .context("missing audio channels")?
             .count();
 


### PR DESCRIPTION
It seems like Symphonia sometimes (at least for my AAC files) reports `channels: None`, but has a `channel_layout`(`: Some(Stereo)`), which can be converted to `Channels`. This PR adds a fallback to that value.

<details>
<summary>Debug output from the file</summary>

```txt
DEBUG: Track {
    id: 2,
    codec_params: CodecParameters {
        codec: CodecType(
            4100,
        ),
        sample_rate: Some(
            44100,
        ),
        time_base: Some(
            TimeBase {
                numer: 1000000,
                denom: 1000000000,
            },
        ),
        n_frames: Some(
            175031,
        ),
        start_ts: 0,
        sample_format: Some(
            S32,
        ),
        bits_per_sample: Some(
            32,
        ),
        bits_per_coded_sample: None,
        channels: None,
        channel_layout: Some(
            Stereo,
        ),
        delay: None,
        padding: None,
        max_frames_per_packet: None,
        packet_data_integrity: false,
        verification_check: None,
        frames_per_block: None,
        extra_data: Some(
            [
                18,
                16,
                86,
                229,
                0,
            ],
        ),
    },
    language: Some(
        "und",
    ),
}
```

</details>